### PR TITLE
fft_poisson() function returns potential along with E_x, E_y, E_z

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,19 @@ The solver makes use of [ArrayFire](https://github.com/arrayfire/arrayfire) and 
 
 Once [ArrayFire](https://github.com/arrayfire/arrayfire) is installed successfully, all other dependencies can be installed using `pip install -r requirements.txt`
 
+## Installation:
+
+- First build [ArrayFire](https://github.com/arrayfire/arrayfire) from source. Suggested installation folder: `${HOME}/arrayfire`
+- This code needs Python3 to run. Suggested install : [Anaconda for Python3](https://www.continuum.io/downloads)
+- After installing Anaconda, type `which python` in the terminal. Output should show that python from Anaconda is being used.
+- Next, inside the Poisson_Solver folder, use: `pip install -r requirements.txt` to install required Python3 libraries.
+
 ## Usage:
 
 The function `fft_poisson` assumes that in the density array, `x` varies along axis 0, `y` varies along axis 1, `z` varies along axis 2. Additionally, we consider cell centered formulation to be used throughout. Hence the density array needs to be passed to the function following these conventions:
 ```python
 from fft_poisson_3d import fft_poisson
-Ex, Ey, Ez = fft_poisson(rho, dx, dy, dz)
+potential, Ex, Ey, Ez = fft_poisson(rho, dx, dy, dz)
 ```
 ## Testing:
 

--- a/fft_poisson_3d.py
+++ b/fft_poisson_3d.py
@@ -34,6 +34,8 @@ def fft_poisson(rho, dx, dy, dz):
 
     potential_hat = rho_hat / (4 * np.pi**2 * (k_x**2 + k_y**2 + k_z**2))
 
+    # At the zeroth index, k_x = K_y = k_z = 0
+    # Setting potential_hat's zeroth indices manually to avoid ZeroDivisionError
     potential_hat[0, 0, 0] = 0
 
     Ex_hat = -1j * 2 * np.pi * k_x * potential_hat
@@ -43,5 +45,7 @@ def fft_poisson(rho, dx, dy, dz):
     Ex = af.ifft3(Ex_hat)
     Ey = af.ifft3(Ey_hat)
     Ez = af.ifft3(Ez_hat)
+    
+    potential = af.ifft3(potential_hat)
 
-    return(Ex, Ey, Ez)
+    return(potential, Ex, Ey, Ez)

--- a/test_fft_poisson_3d.py
+++ b/test_fft_poisson_3d.py
@@ -14,6 +14,9 @@ def test_fft_poisson():
     solution as given by the FFT solver and the analytical
     solution correspond well with each other.
     """
+    
+    af.set_backend('cpu')
+    
     x_start = 0
     y_start = 0
     z_start = 0
@@ -25,6 +28,10 @@ def test_fft_poisson():
     N_x = np.random.randint(16, 32)
     N_y = np.random.randint(16, 32)
     N_z = np.random.randint(16, 32)
+    
+    print ("N_x", N_x)
+    print ("N_y", N_y)
+    print ("N_z", N_z)
 
     dx = (x_end - x_start) / N_x
     dy = (y_end - y_start) / N_y
@@ -52,13 +59,19 @@ def test_fft_poisson():
     Ez_analytic = -(6 * np.pi) / (56 * np.pi**2) * \
                   af.cos(2 * np.pi * x + 4 * np.pi * y + 6 * np.pi * z)
 
-    Ex_numerical, Ey_numerical, Ez_numerical = fft_poisson(rho, dx, dy, dz)
+    potential, Ex_numerical, Ey_numerical, Ez_numerical = fft_poisson(rho, dx, dy, dz)
 
     # Checking that the L1 norm of error is at machine precision:
     Ex_err = af.sum(af.abs(Ex_numerical - Ex_analytic)) / Ex_analytic.elements()
     Ey_err = af.sum(af.abs(Ey_numerical - Ey_analytic)) / Ey_analytic.elements()
     Ez_err = af.sum(af.abs(Ez_numerical - Ez_analytic)) / Ez_analytic.elements()
+    
+    print ("Ex_err : ",Ex_err)
+    print ("Ey_err : ",Ey_err)
+    print ("Ez_err : ",Ez_err)
 
     assert(Ex_err < 1e-14)
     assert(Ey_err < 1e-14)
     assert(Ez_err < 1e-14)
+    
+test_fft_poisson()


### PR DESCRIPTION
- In `fft_poisson.py` : 
    - `fft_poisson()` now returns `potential`, along with `E_x`, `E_y` and `E_z`
    - added comment to explain `potential[0, 0, 0] = 0`
- In `test_fft_poisson_3d.py` : 
    - added line to execute `test_fft_poission()`
    - swiched ArrayFire backend to `'cpu'` (Issue #1)
    - printed out `Ex_err`, `Ex_err`, `Ex_err`, `N_x`, `N_y` and `N_z` (Issue #2)